### PR TITLE
Add interactive presentation template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Math Presentation Template
+
+This project generates an interactive HTML slide deck using [reveal.js](https://revealjs.com/) and KaTeX.
+
+## Usage
+
+1. Place your slide content in `slides.md` using Markdown.
+2. Run the build script:
+
+```bash
+python3 build.py
+```
+
+This produces `index.html` that you can open in a browser.
+
+Slides support fragments for stepwise revealing and include an example Desmos graph on the slide titled *Interaktives Diagramm*.

--- a/build.py
+++ b/build.py
@@ -1,0 +1,15 @@
+import argparse, pathlib
+
+def build(slides_path: str, output: str):
+    template = pathlib.Path('template.html').read_text()
+    slides = pathlib.Path(slides_path).read_text()
+    html = template.replace('{{slides}}', slides)
+    pathlib.Path(output).write_text(html)
+    print(f'Generated {output} from {slides_path}')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Build presentation')
+    parser.add_argument('slides', nargs='?', default='slides.md')
+    parser.add_argument('-o', '--output', default='index.html')
+    args = parser.parse_args()
+    build(args.slides, args.output)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mathe Präsentation</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/theme/black.css" id="theme">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="reveal">
+    <div class="slides">
+# Klammern ausmultiplizieren
+
+- <span class="fragment">Bei mehreren Faktoren: jeden genau einmal verwenden, die Reihenfolge spielt keine Rolle</span>
+- <span class="fragment">Beispiel $3x\,(2x+5y^{2}) = 6x^{2} + 15xy^{2}$</span>
+- <span class="fragment">Beispiel $(-7xz^{3}+3xy^{2})\cdot(-2xz) = 14x^{2}z^{4}-6x^{2}y^{2}z$</span>
+- <span class="fragment">Beispiel $(3x-7y)(2x+5y) = 6x^{2}+15xy-14xy-35y^{2}=6x^{2}+xy-35y^{2}$</span>
+- <span class="fragment">Beispiel $2(x+3)(x+7) = 2x^{2}+20x+42$</span>
+- <span class="fragment">Beispiel $3x^{2}(x-3)(9x-1)=27x^{4}-84x^{3}+9x^{2}$</span>
+
+---
+# Die drei binomischen Formeln
+
+- <span class="fragment">$(a+b)^{2}=a^{2}+2ab+b^{2}$</span>
+- <span class="fragment">$(a-b)^{2}=a^{2}-2ab+b^{2}$</span>
+- <span class="fragment">$(a+b)(a-b)=a^{2}-b^{2}$</span>
+
+---
+# Schnelles Ausmultiplizieren mittels Binomen
+
+- <span class="fragment">$(u-10)(u+10)=u^{2}-100$</span>
+- <span class="fragment">$(x+3y)^{2}=x^{2}+6xy+9y^{2}$</span>
+- <span class="fragment">$(5x-4z)^{2}=25x^{2}-40xz+16z^{2}$</span>
+- <span class="fragment">$(x^{2}y+1)(x^{2}y-1)=x^{4}y^{2}-1$</span>
+- <span class="fragment">$(2x-w^{10})^{2}=4x^{2}-4xw^{10}+w^{20}$</span>
+- <span class="fragment">$\bigl(w+\tfrac43\bigr)^{2}=w^{2}+\tfrac83w+\tfrac{16}{9}$</span>
+
+---
+# Faktorisieren (Zweiklammer-Ansatz)
+
+1. <span class="fragment">$x^{2}+1x-6 \to (x-2)(x+3)$</span>
+2. <span class="fragment">$p\cdot q=-6$ und $p+q=1$</span>
+3. <span class="fragment">Systematisches Probieren der Paare</span>
+
+---
+# Einsetzverfahren
+
+$$
+\begin{cases}
+2y = 7 + x &\text{(I)}\\
+-3x+8 = y+1 &\text{(II)}
+\end{cases}
+$$
+
+1. <span class="fragment">Gleichung (II) nach $x$ auflösen: $x=\tfrac{y}{-3}+\tfrac{7}{3}$</span>
+2. <span class="fragment">In (I) einsetzen und $y=4$, $x=1$ erhalten</span>
+3. <span class="fragment">Lösungsmenge $L=\{(1,4)\}$</span>
+
+---
+# Wurzelgleichungen quadrieren
+
+- <span class="fragment">Beispiel: $(5\sqrt{x-2}-6)^{2}$</span>
+- <span class="fragment">Ergebnis: $25(x-2)-60\sqrt{x-2}-14$</span>
+
+---
+# Aufgabe zu Wurzelgleichungen
+
+1. <span class="fragment">$2\sqrt{-2x+2}+3=3x$ &rarr; $2\sqrt{-2x+2}=3x-3$</span>
+2. <span class="fragment">Quadrieren: $4(-2x+2)=9x^{2}-18x+9$</span>
+3. <span class="fragment">$9x^{2}-10x+1=0$ &rarr; $x_{1}=1,\;x_{2}=\tfrac19$</span>
+4. <span class="fragment">Probe ergibt nur $x=1$</span>
+
+---
+# Lineare Funktionen: Delisle &rarr; Kelvin
+
+- <span class="fragment">Stützpunkte $(150,273.15)$ und $(0,373.15)$</span>
+- <span class="fragment">Steigung $m=-\tfrac23$</span>
+- <span class="fragment">Geradengleichung $y=-\tfrac23 x + 373.15$</span>
+
+---
+# Interaktives Diagramm
+
+<div id="desmos-graph" style="width: 100%; height: 500px;"></div>
+
+---
+# Ende
+
+Danke f&uuml;r die Aufmerksamkeit!
+
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/plugin/markdown/markdown.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/plugin/highlight/highlight.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/plugin/math/math.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js"></script>
+  <script src="slides.js"></script>
+</body>
+</html>

--- a/slides.js
+++ b/slides.js
@@ -1,0 +1,36 @@
+(function(){
+  const deck = new Reveal({
+    hash: true,
+    slideNumber: true,
+    plugins: [ RevealMarkdown, RevealHighlight, RevealMath.KaTeX ]
+  })
+  deck.initialize();
+
+  // render math with KaTeX after markdown processing
+  document.addEventListener('DOMContentLoaded', function(){
+    renderMathInElement(document.body, {delimiters:[{left:'$$',right:'$$',display:true},{left:'$',right:'$',display:false}]});
+  });
+
+  // Desmos interactive graph
+  deck.on('slidechanged', function(event){
+    if(event.currentSlide && event.currentSlide.querySelector('#desmos-graph')){
+      if(!window.Calculator){
+        const script = document.createElement('script');
+        script.src = 'https://www.desmos.com/api/v1.6/calculator.js?apiKey=demo';
+        script.onload = createGraph;
+        document.head.appendChild(script);
+      } else {
+        createGraph();
+      }
+    }
+  });
+
+  function createGraph(){
+    const elt = document.getElementById('desmos-graph');
+    if(!elt) return;
+    if(elt.dataset.initialized) return;
+    const calc = Desmos.GraphingCalculator(elt,{expressions:false});
+    calc.setExpression({id:'line', latex:'y=-\frac{2}{3}x+373.15'});
+    elt.dataset.initialized = true;
+  }
+})();

--- a/slides.md
+++ b/slides.md
@@ -1,0 +1,77 @@
+# Klammern ausmultiplizieren
+
+- <span class="fragment">Bei mehreren Faktoren: jeden genau einmal verwenden, die Reihenfolge spielt keine Rolle</span>
+- <span class="fragment">Beispiel $3x\,(2x+5y^{2}) = 6x^{2} + 15xy^{2}$</span>
+- <span class="fragment">Beispiel $(-7xz^{3}+3xy^{2})\cdot(-2xz) = 14x^{2}z^{4}-6x^{2}y^{2}z$</span>
+- <span class="fragment">Beispiel $(3x-7y)(2x+5y) = 6x^{2}+15xy-14xy-35y^{2}=6x^{2}+xy-35y^{2}$</span>
+- <span class="fragment">Beispiel $2(x+3)(x+7) = 2x^{2}+20x+42$</span>
+- <span class="fragment">Beispiel $3x^{2}(x-3)(9x-1)=27x^{4}-84x^{3}+9x^{2}$</span>
+
+---
+# Die drei binomischen Formeln
+
+- <span class="fragment">$(a+b)^{2}=a^{2}+2ab+b^{2}$</span>
+- <span class="fragment">$(a-b)^{2}=a^{2}-2ab+b^{2}$</span>
+- <span class="fragment">$(a+b)(a-b)=a^{2}-b^{2}$</span>
+
+---
+# Schnelles Ausmultiplizieren mittels Binomen
+
+- <span class="fragment">$(u-10)(u+10)=u^{2}-100$</span>
+- <span class="fragment">$(x+3y)^{2}=x^{2}+6xy+9y^{2}$</span>
+- <span class="fragment">$(5x-4z)^{2}=25x^{2}-40xz+16z^{2}$</span>
+- <span class="fragment">$(x^{2}y+1)(x^{2}y-1)=x^{4}y^{2}-1$</span>
+- <span class="fragment">$(2x-w^{10})^{2}=4x^{2}-4xw^{10}+w^{20}$</span>
+- <span class="fragment">$\bigl(w+\tfrac43\bigr)^{2}=w^{2}+\tfrac83w+\tfrac{16}{9}$</span>
+
+---
+# Faktorisieren (Zweiklammer-Ansatz)
+
+1. <span class="fragment">$x^{2}+1x-6 \to (x-2)(x+3)$</span>
+2. <span class="fragment">$p\cdot q=-6$ und $p+q=1$</span>
+3. <span class="fragment">Systematisches Probieren der Paare</span>
+
+---
+# Einsetzverfahren
+
+$$
+\begin{cases}
+2y = 7 + x &\text{(I)}\\
+-3x+8 = y+1 &\text{(II)}
+\end{cases}
+$$
+
+1. <span class="fragment">Gleichung (II) nach $x$ auflösen: $x=\tfrac{y}{-3}+\tfrac{7}{3}$</span>
+2. <span class="fragment">In (I) einsetzen und $y=4$, $x=1$ erhalten</span>
+3. <span class="fragment">Lösungsmenge $L=\{(1,4)\}$</span>
+
+---
+# Wurzelgleichungen quadrieren
+
+- <span class="fragment">Beispiel: $(5\sqrt{x-2}-6)^{2}$</span>
+- <span class="fragment">Ergebnis: $25(x-2)-60\sqrt{x-2}-14$</span>
+
+---
+# Aufgabe zu Wurzelgleichungen
+
+1. <span class="fragment">$2\sqrt{-2x+2}+3=3x$ &rarr; $2\sqrt{-2x+2}=3x-3$</span>
+2. <span class="fragment">Quadrieren: $4(-2x+2)=9x^{2}-18x+9$</span>
+3. <span class="fragment">$9x^{2}-10x+1=0$ &rarr; $x_{1}=1,\;x_{2}=\tfrac19$</span>
+4. <span class="fragment">Probe ergibt nur $x=1$</span>
+
+---
+# Lineare Funktionen: Delisle &rarr; Kelvin
+
+- <span class="fragment">Stützpunkte $(150,273.15)$ und $(0,373.15)$</span>
+- <span class="fragment">Steigung $m=-\tfrac23$</span>
+- <span class="fragment">Geradengleichung $y=-\tfrac23 x + 373.15$</span>
+
+---
+# Interaktives Diagramm
+
+<div id="desmos-graph" style="width: 100%; height: 500px;"></div>
+
+---
+# Ende
+
+Danke f&uuml;r die Aufmerksamkeit!

--- a/style.css
+++ b/style.css
@@ -1,0 +1,17 @@
+body {
+  background: #111;
+  color: #eee;
+}
+.reveal h1,
+.reveal h2,
+.reveal h3,
+.reveal h4 {
+  color: #8bc34a;
+}
+.reveal .fragment {
+  transition: opacity 0.5s ease;
+}
+/* highlight numbers */
+.reveal .hl-num {
+  color: #ff9800;
+}

--- a/template.html
+++ b/template.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mathe Präsentation</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/theme/black.css" id="theme">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="reveal">
+    <div class="slides">
+{{slides}}
+    </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/plugin/markdown/markdown.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/plugin/highlight/highlight.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/plugin/math/math.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js"></script>
+  <script src="slides.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- convert provided slide text into a Markdown file
- create HTML template using reveal.js and KaTeX
- add JavaScript for slide deck and Desmos demo
- provide build script and CSS for dark theme
- include generated `index.html` and usage instructions

## Testing
- `python3 build.py`

------
https://chatgpt.com/codex/tasks/task_e_6864e3c133788326b7e24c227a1ec9b1