### PR TITLE
Improve heading placement

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,6 +1,6 @@
 body {
     margin: 0;
-    font-family: 'Verdana', sans-serif;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
     background: #121212;
     color: #e0e0e0;
     line-height: 1.6;
@@ -74,15 +74,16 @@ body {
 .slide.active {
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    justify-content: flex-start;
+    align-items: flex-start;
     text-align: left;
     opacity: 1;
 }
 h1 {
-    font-family: 'Georgia', serif;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
     color: #ffd166;
-    margin-top: 60px;
+    margin-top: 20px;
+    font-size: 2.5em;
 }
 .math {
     color: #8ecae6;
@@ -112,4 +113,29 @@ th, td {
 }
 th {
     background: #333;
+}
+
+#controls {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 15px;
+    z-index: 1000;
+}
+
+#controls button {
+    background: #ffd166;
+    border: none;
+    color: #121212;
+    padding: 10px 18px;
+    font-size: 18px;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+#controls button:focus {
+    outline: none;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -3,6 +3,9 @@ const slides = document.querySelectorAll('.slide');
 const progress = document.getElementById('progress');
 const menu = document.getElementById('menu');
 const menuToggle = document.getElementById('menuToggle');
+const prevSlideBtn = document.getElementById('prevSlideBtn');
+const nextFragmentBtn = document.getElementById('nextFragmentBtn');
+const nextSlideBtn = document.getElementById('nextSlideBtn');
 const showSlide = (index) => {
     if (index < 0 || index >= slides.length) return;
     slides[currentSlide].classList.remove('active');
@@ -29,16 +32,21 @@ const prevSlide = () => {
     showSlide(currentSlide - 1);
 };
 document.addEventListener('keydown', (e) => {
-    if (e.key === 'ArrowRight' || e.key === ' ') {
+    if (document.activeElement !== document.body) return;
+    if (e.key === ' ') {
         nextFragmentOrSlide();
+    } else if (e.key === 'ArrowRight') {
+        showSlide(currentSlide + 1);
     } else if (e.key === 'ArrowLeft') {
         prevSlide();
     } else if (e.key.toLowerCase() === 'm') {
         toggleMenu();
     }
 });
-document.addEventListener('click', nextFragmentOrSlide);
 menuToggle.addEventListener('click', toggleMenu);
+if (prevSlideBtn) prevSlideBtn.addEventListener('click', prevSlide);
+if (nextFragmentBtn) nextFragmentBtn.addEventListener('click', nextFragmentOrSlide);
+if (nextSlideBtn) nextSlideBtn.addEventListener('click', () => showSlide(currentSlide + 1));
 menu.querySelectorAll('a').forEach(a => {
     a.addEventListener('click', (e) => {
         e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -132,6 +132,11 @@
         </table>
     </section>
 </div>
+<div id="controls">
+    <button id="prevSlideBtn">&#9664; Zurück</button>
+    <button id="nextFragmentBtn">Weiter</button>
+    <button id="nextSlideBtn">Nächste Folie &#9654;</button>
+</div>
 <script src="https://www.desmos.com/api/v1.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>
 <script src="assets/js/script.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- align slide content to the top so headings don't shift
- preserve added navigation buttons and sans-serif fonts

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864ece5a9508326bf4cb12283324614