### PR TITLE
Add markdown upload and slide generation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -68,3 +68,9 @@ th{ background:var(--bg-800); font-weight:600; }
 
 /* Farbliche Helfer */
 .rot{color:#ef4444;} .blau{color:var(--accent);} .gruen{color:#10b981;}
+
+input[type=range]{width:100%}
+button{padding:.4em .8em;cursor:pointer;background:var(--accent);border:none;border-radius:4px;color:#fff;}
+button:hover{background:var(--accent-light);}
+.hidden{display:none}
+.visible{display:block}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,8 +1,85 @@
-// Initialize Desmos graph on load
-window.addEventListener('load', () => {
+document.addEventListener('slides-ready', () => {
+  let currentSlide = 0;
+  const slides = document.querySelectorAll('.slide');
+  const progress = document.getElementById('progress');
+  const menu = document.getElementById('menu');
+  const menuToggle = document.getElementById('menuToggle');
+  const prevSlideBtn = document.getElementById('prevSlideBtn');
+  const nextFragmentBtn = document.getElementById('nextFragmentBtn');
+  const nextSlideBtn = document.getElementById('nextSlideBtn');
+
+  const showSlide = (index) => {
+    if (index < 0 || index >= slides.length) return;
+    slides[currentSlide].classList.remove('active');
+    currentSlide = index;
+    slides[currentSlide].classList.add('active');
+    resetFragments(slides[currentSlide]);
+    updateProgress();
+  };
+
+  const resetFragments = (slide) => {
+    slide.querySelectorAll('.fragment').forEach(f => f.classList.remove('visible'));
+    fragmentIndex = 0;
+  };
+
+  let fragmentIndex = 0;
+  const nextFragmentOrSlide = () => {
+    const fragments = slides[currentSlide].querySelectorAll('.fragment');
+    if (fragmentIndex < fragments.length) {
+      fragments[fragmentIndex].classList.add('visible');
+      fragmentIndex++;
+    } else {
+      showSlide(currentSlide + 1);
+    }
+  };
+
+  const prevSlide = () => {
+    showSlide(currentSlide - 1);
+  };
+
+  document.addEventListener('keydown', (e) => {
+    if (document.activeElement !== document.body) return;
+    if (e.key === ' ') {
+      nextFragmentOrSlide();
+    } else if (e.key === 'ArrowRight') {
+      showSlide(currentSlide + 1);
+    } else if (e.key === 'ArrowLeft') {
+      prevSlide();
+    } else if (e.key.toLowerCase() === 'm') {
+      toggleMenu();
+    }
+  });
+
+  if (menuToggle) menuToggle.addEventListener('click', toggleMenu);
+  if (prevSlideBtn) prevSlideBtn.addEventListener('click', prevSlide);
+  if (nextFragmentBtn) nextFragmentBtn.addEventListener('click', nextFragmentOrSlide);
+  if (nextSlideBtn) nextSlideBtn.addEventListener('click', () => showSlide(currentSlide + 1));
+
+  if (menu) menu.querySelectorAll('a').forEach(a => {
+    a.addEventListener('click', (e) => {
+      e.preventDefault();
+      const n = parseInt(a.dataset.slide, 10);
+      toggleMenu();
+      showSlide(n);
+    });
+  });
+
+  showSlide(0);
+  MathJax.typesetPromise();
+
+  // Desmos graph
   const el = document.getElementById('desmos');
   if (el) {
     const calculator = Desmos.GraphingCalculator(el, { expressions: false });
     calculator.setExpression({ id: 'line', latex: 'y=-2/3 x + 373.15' });
+  }
+
+  function updateProgress() {
+    const percent = ((currentSlide + 1) / slides.length) * 100;
+    if (progress) progress.style.width = percent + '%';
+  }
+
+  function toggleMenu() {
+    if (menu) menu.classList.toggle('visible');
   }
 });

--- a/assets/js/slide-engine.js
+++ b/assets/js/slide-engine.js
@@ -1,0 +1,33 @@
+/* ---------- Upload-Handling ---------- */
+const dz     = document.getElementById('dropZone');
+const input  = document.getElementById('mdUpload');
+
+/* Hover-Feedback */
+['dragenter','dragover'].forEach(ev =>
+  dz.addEventListener(ev, e => { e.preventDefault(); dz.classList.add('hover'); }));
+['dragleave','drop'].forEach(ev =>
+  dz.addEventListener(ev, e => { e.preventDefault(); dz.classList.remove('hover'); }));
+
+dz.addEventListener('drop',   e => processFile(e.dataTransfer.files[0]));
+input.addEventListener('change', e => processFile(e.target.files[0]));
+
+/* Datei lesen & Slides bauen */
+function processFile(file){
+  if(!file || !file.name.endsWith('.md')) return alert('Bitte eine .md Datei wählen!');
+  const reader = new FileReader();
+  reader.onload = () => buildSlides(reader.result);
+  reader.readAsText(file,'utf-8');
+}
+
+function buildSlides(md){
+  const host = document.getElementById('slides');
+  host.innerHTML = '';
+  md.split(/^---$/m).forEach((chunk,i)=>{
+    const sec = document.createElement('section');
+    sec.className = 'slide';
+    sec.id        = `slide${i+1}`;
+    sec.innerHTML = marked.parse(chunk.trim());
+    host.appendChild(sec);
+  });
+  document.dispatchEvent(new Event('slides-ready'));   // Trigger Navigation
+}

--- a/assets/js/widget-factory.js
+++ b/assets/js/widget-factory.js
@@ -1,0 +1,31 @@
+document.addEventListener('slides-ready', () => {
+  document.querySelectorAll('widget').forEach(node => {
+    const type = node.getAttribute('type');
+    ({ slider:makeSlider, reveal:makeReveal }[type]||(()=>{}))(node);
+  });
+});
+
+function makeSlider(host){
+  const tgtId = host.dataset.for;
+  const inp   = Object.assign(document.createElement('input'),{
+    type:'range',
+    min :host.dataset.min||0,
+    max :host.dataset.max||10,
+    value:host.dataset.init||0
+  });
+  inp.oninput = () => {
+    const x   = Number(inp.value);
+    const res = Function('x', `return ${host.dataset.fn}`)(x);   // z. B. "`x*x`"
+    document.getElementById(tgtId).innerHTML = res;
+    MathJax.typesetPromise();
+  };
+  host.replaceWith(inp);
+}
+
+function makeReveal(host){
+  const tgt = document.getElementById(host.dataset.for);
+  const btn = document.createElement('button');
+  btn.textContent = host.dataset.label||'Zeigen';
+  btn.onclick = () => tgt.classList.toggle('visible');
+  host.replaceWith(btn);
+}

--- a/index.html
+++ b/index.html
@@ -2,143 +2,80 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Mathematik-Folien</title>
+  <title>Markdown → Interaktive Präsentation</title>
 
-  <!-- Reveal Grund-CSS  -->
-  <link rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.css">
-  <link rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/theme/black.css" id="theme">
+  <!-- ---------- DESIGN ---------- -->
+  <style>
+    :root{
+      --bg-900:#0e1117; --bg-800:#161b22; --bg-700:#1f242c;
+      --accent:#3b82f6; --accent-light:#60a5fa;
+      --txt-100:#f3f4f6; --txt-300:#d1d5db;
+    }
+    *{box-sizing:border-box;margin:0;padding:0}
+    html,body{height:100%;font-family:"Inter",system-ui,sans-serif;background:var(--bg-900);color:var(--txt-100);}
+    body{display:flex;flex-direction:column;align-items:center;padding-top:4vh;}
+    h1{font-size:clamp(1.3rem,2vw+1rem,1.8rem);font-weight:600;margin-bottom:1.6rem;text-align:center;}
 
-  <!-- Eigenes Dark-Theme (identisch zur Upload-Seite) -->
-  <link rel="stylesheet" href="assets/css/style.css">
+    /* Upload\u2011Card */
+    #dropZone{
+      width:min(520px,90vw);min-height:200px;
+      background:var(--bg-800);
+      border:2px dashed var(--accent-light);
+      border-radius:16px;
+      display:flex;flex-direction:column;align-items:center;justify-content:center;
+      gap:1rem;padding:2.5rem 2rem;
+      transition:border-color .25s,background .25s,transform .35s ease;
+      box-shadow:0 0 0 1px var(--bg-700),0 10px 20px rgba(0,0,0,.35);
+    }
+    #dropZone.hover{background:var(--bg-700);border-color:var(--accent);}
+    #dropZone:active{transform:scale(.97);}
+    #dropZone svg{fill:var(--accent-light);opacity:.9;transition:fill .25s;}
+    #dropZone.hover svg{fill:var(--accent);}
+    #dropZone p{color:var(--txt-300);font-size:.95rem;}
+    #mdUpload{display:none;}
 
-  <!-- Polyfills & MathJax -->
+    /* Slides\u2011Host */
+    #slides{width:100%;margin-top:6vh;}
+    #placeholder{color:var(--txt-300);text-align:center;margin-top:4rem;font-size:1rem;line-height:1.6;}
+
+    /* Global Erg\u00e4nzungen */
+    input[type=range]{width:100%}
+    button{padding:.4em .8em;cursor:pointer;background:var(--accent);border:none;border-radius:4px;color:#fff;}
+    button:hover{background:var(--accent-light);}
+    .hidden{display:none}
+    .visible{display:block}
+  </style>
+
+  <!-- ---------- LIBS ---------- -->
   <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script async id="MathJax-script"
           src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
-
 <body>
-<div class="reveal"><div class="slides">
 
-<!-- ====================================================== -->
-<section>
-  <h2>Klammern: jeden Term mit jedem anderen multiplizieren</h2>
-  <ul>
-    <li class="fragment">Bei mehreren Faktoren: jeden genau einmal verwenden, die Reihenfolge spielt keine Rolle</li>
-    <li class="fragment math">\(3x\,(2x+5y^{2}) = 6x^{2} + 15xy^{2}\)</li>
-    <li class="fragment math">\((-7xz^{3}+3xy^{2})\cdot(-2xz) = 14x^{2}z^{4}-6x^{2}y^{2}z\)</li>
-    <li class="fragment math">\((3x-7y)(2x+5y) = 6x^{2}+xy-35y^{2}\)</li>
-    <li class="fragment math">\(2(x+3)(x+7) = 2x^{2}+20x+42\)</li>
-    <li class="fragment math">\(3x^{2}(x-3)(9x-1) = 27x^{4}-84x^{3}+9x^{2}\)</li>
-  </ul>
-</section>
+  <h1>Interaktive Präsentation aus&nbsp;Markdown erzeugen</h1>
 
-<section>
-  <h2>Binomische Formeln – Abkürzung für häufige Produkte</h2>
-  <ul>
-    <li class="fragment math">\((a+b)^{2}=a^{2}+2ab+b^{2}\)</li>
-    <li class="fragment math">\((a-b)^{2}=a^{2}-2ab+b^{2}\)</li>
-    <li class="fragment math">\((a+b)(a-b)=a^{2}-b^{2}\)</li>
-  </ul>
-</section>
+  <!-- Upload -->
+  <label id="dropZone">
+    <input type="file" id="mdUpload" accept=".md">
+    <svg xmlns="http://www.w3.org/2000/svg" height="68" viewBox="0 0 24 24">
+      <path d="M12 16l4-5h-3V4h-2v7H8l4 5z"/><path d="M20 18H4v-2h16v2z"/>
+    </svg>
+    <p><strong>Datei hierher ziehen</strong> oder klicken …</p>
+  </label>
 
-<section>
-  <h2>Schnelles Ausmultiplizieren mittels Binomen</h2>
-  <ul>
-    <li class="fragment math">\((u-10)(u+10)=u^{2}-100\)</li>
-    <li class="fragment math">\((x+3y)^{2}=x^{2}+6xy+9y^{2}\)</li>
-    <li class="fragment math">\((5x-4z)^{2}=25x^{2}-40xz+16z^{2}\)</li>
-    <li class="fragment math">\((x^{2}y+1)(x^{2}y-1)=x^{4}y^{2}-1\)</li>
-    <li class="fragment math">\((2x-w^{10})^{2}=4x^{2}-4xw^{10}+w^{20}\)</li>
-    <li class="fragment math">\((w+\tfrac{4}{3})^{2}=w^{2}+\tfrac{8}{3}w+\tfrac{16}{9}\)</li>
-  </ul>
-</section>
+  <!-- Slides -->
+  <div id="slides">
+    <div id="placeholder">
+      <p>Noch keine Präsentation geladen.</p>
+      <p>Lade eine <code>.md</code>-Datei hoch, um loszulegen.</p>
+    </div>
+  </div>
 
-<section>
-  <h2>Faktorisieren – Zweiklammer-Ansatz</h2>
-  <p class="fragment">Beispiel: \(x^{2}+1x-6\) → \((x-2)(x+3)\)</p>
-  <ol>
-    <li class="fragment">Faktor \(x\) aus \(x^{2}\) → erste Glieder</li>
-    <li class="fragment">Zerlege \(-6\) in Paare, teste bis Mittelterm passt</li>
-    <li class="fragment">Faktorisiert: \((x-2)(x+3)\)</li>
-  </ol>
-</section>
-
-<section>
-  <h2>Einsetzverfahren (Gleichungssystem)</h2>
-  <p>\(\begin{cases}2y = 7 + x\\-3x+8 = y+1\end{cases}\)</p>
-  <ol>
-    <li class="fragment">Löse (II) nach \(x\) → \(x=\tfrac{y}{-3}+\tfrac{7}{3}\)</li>
-    <li class="fragment">Setze in (I) ein → \(y=4\)</li>
-    <li class="fragment">Ergebnis: \(x=1\), Lösung \(L=\{(1,4)\}\)</li>
-  </ol>
-</section>
-
-<section>
-  <h2>Wurzelgleichungen quadrieren</h2>
-  <p class="fragment math">\((5\sqrt{x-2}-6)^{2}=25(x-2)-60\sqrt{x-2}+36\)</p>
-</section>
-
-<section>
-  <h2>Wurzelgleichungen – vollständige Lösung</h2>
-  <ol>
-    <li class="fragment">Ausgang: \(2\sqrt{-2x+2}+3=3x\)</li>
-    <li class="fragment">Quadrieren → \(9x^{2}-10x+1=0\)</li>
-    <li class="fragment">Lösungen: \(x_{1}=1,\;x_{2}=\tfrac19\) (Probe → nur \(x=1\))</li>
-  </ol>
-</section>
-
-<section>
-  <h2>Lineare Funktionen – Delisle ↔ Kelvin</h2>
-  <ul>
-    <li class="fragment">Stützpunkte: \((150,273{,}15)\) & \((0,373{,}15)\)</li>
-    <li class="fragment">Steigung: \(m=-\tfrac23\)</li>
-    <li class="fragment">Gerade: \(y=-\tfrac23x+373{,}15\)</li>
-  </ul>
-</section>
-
-<section>
-  <h2>Interaktives Diagramm</h2>
-  <div id="desmos" class="desmos-graph"></div>
-</section>
-
-<section>
-  <h2>Zusammenfassung</h2>
-  <table>
-    <thead><tr><th>Thema</th><th>Konzept</th></tr></thead>
-    <tbody>
-      <tr><td>Klammern</td><td>Distributivgesetz</td></tr>
-      <tr><td>Binomische Formeln</td><td>Spezial-Produkte</td></tr>
-      <tr><td>Faktorisieren</td><td>Zweiklammer-Ansatz</td></tr>
-      <tr><td>Einsetzverfahren</td><td>Lineare Gleichungen</td></tr>
-      <tr><td>Wurzelgleichungen</td><td>Radikale eliminieren</td></tr>
-      <tr><td>Lineare Funktionen</td><td>Gerade durch 2 Punkte</td></tr>
-    </tbody>
-  </table>
-</section>
-<!-- ====================================================== -->
-
-</div></div><!-- reveal / slides -->
-
-<!-- Reveal- & Desmos-JS -->
-<script src="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.js"></script>
-<script src="https://www.desmos.com/api/v1.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>
-<script src="assets/js/script.js"></script>
-
-<script>
-  /*  >>>  Reveal Setup  — kein Auto-Scaling mehr  <<<  */
-  Reveal.initialize({
-    hash: true,
-    slideNumber: true,
-    width: 1280,
-    height: 720,
-    margin: 0.05,
-    minScale: 1,
-    maxScale: 1
-  });
-</script>
+  <!-- Scripts -->
+  <script src="assets/js/slide-engine.js"></script>
+  <script src="assets/js/widget-factory.js"></script>
+  <script src="assets/js/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement new drag-and-drop homepage
- generate slides from uploaded Markdown
- convert `<widget>` tags into interactive elements
- start navigation and Desmos setup after slides load
- extend CSS for controls and widgets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686504f3270083269eac112d1fd216e8