### PR TITLE
Add markdown upload and dynamic slide viewer

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,70 +1,34 @@
-/* ========== Dark‑Theme – Präsentation (v2)  ==========
-   Größere, präsentationstaugliche Typografie
-   Orientierung: Apple Keynote & Google Slides (Titel ≈ 34‑40 px, Body ≈ 20‑24 px) */
+/* Farbpalette */
 :root{
-  /* Farbschema = Upload‑Startseite */
   --bg-900:#0e1117; --bg-800:#161b22; --bg-700:#1f242c;
-  --accent:#3b82f6; --txt-100:#f3f4f6; --txt-300:#d1d5db;
-
-  /*  --------  Feste Schriftgrößen  --------  */
-  --fs-heading:2.15rem; /*  ≈ 34 px @16 px root  */
-  --fs-body:1.275rem;   /*  ≈ 20 px              */
-  --fs-small:1.05rem;   /*  ≈ 17 px (Tabellen)   */
+  --accent:#3b82f6; --accent-light:#60a5fa;
+  --txt-100:#f3f4f6; --txt-300:#d1d5db;
 }
 
-/*  -------  Layout  ------- */
-body{
-  margin:0;
-  font-family:"Inter","Helvetica Neue",Arial,sans-serif;
-  background:var(--bg-900);
-  color:var(--txt-100);
+/* Grundlayout (gilt f\u00fcr beide Seiten) */
+*{box-sizing:border-box;margin:0;padding:0}
+html,body{height:100%;font-family:"Inter",system-ui,sans-serif;background:var(--bg-900);color:var(--txt-100);}
+.title{text-align:center;font-size:clamp(1.3rem,2vw+1rem,1.8rem);margin:2rem 0 1rem}
+
+/* Upload‑Card */
+#dropZone{
+  width:min(520px,90vw);min-height:200px;background:var(--bg-800);
+  border:2px dashed var(--accent-light);border-radius:16px;
+  display:flex;flex-direction:column;align-items:center;justify-content:center;
+  gap:1rem;padding:2.5rem 2rem;transition:.25s;border-style:dashed;
+  box-shadow:0 0 0 1px var(--bg-700),0 10px 20px rgba(0,0,0,.35);
 }
+#dropZone.hover{background:var(--bg-700);border-color:var(--accent);}
+#dropZone:active{transform:scale(.97);}
+#dropZone svg{fill:var(--accent-light);opacity:.9;transition:fill .25s;}
+#dropZone.hover svg{fill:var(--accent);}
+#dropZone p{color:var(--txt-300);font-size:.95rem;text-align:center}
+#mdUpload{display:none}
 
-.reveal .slides{ max-width:80rem; /* ~1280 px */ }
+/* Globale Widget‑Styles */
+input[type=range]{width:100%}
+button{padding:.4em .8em;border:none;border-radius:4px;cursor:pointer;
+       background:var(--accent);color:#fff;font-size:.9rem}
+button:hover{background:var(--accent-light);}
+.hidden{display:none}.visible{display:block}
 
-/*  -------  Typografie  ------- */
-.reveal h1,
-.reveal h2{
-  font-size:var(--fs-heading) !important;
-  line-height:1.22;
-  margin:0 0 1.1em;
-  font-weight:600;
-  text-align:center;
-}
-
-.reveal h3{
-  font-size:1.5rem;        /* ≈ 24 px */
-  line-height:1.28;
-  margin:0 0 .9em;
-  font-weight:600;
-}
-
-.reveal p,
-.reveal li{
-  font-size:var(--fs-body);
-  line-height:1.6;
-  margin-bottom:.55em;
-}
-
-/* Listen – klare Abstände + etwas größeren Bullet */
-.reveal ul{ padding-left:1.4em; }
-.reveal ul li::marker{ color:var(--accent); font-size:.9em; }
-
-/* Tabellen – kompakt aber lesbar */
-table{ border-collapse:collapse; width:65rem; max-width:100%; margin:auto; }
-th,td{
-  font-size:var(--fs-small);
-  padding:.55em .75em;
-  border:1px solid var(--bg-700);
-}
-th{ background:var(--bg-800); font-weight:600; }
-
-/* Desmos & Graph‑Boxen */
-.desmos-graph{
-  width:100%; height:460px; margin:1.2em auto;
-  border:1px solid var(--bg-700); border-radius:10px;
-  box-shadow:0 4px 12px rgba(0,0,0,.4);
-}
-
-/* Farbliche Helfer */
-.rot{color:#ef4444;} .blau{color:var(--accent);} .gruen{color:#10b981;}

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,3 +1,4 @@
+document.addEventListener('slides-ready', () => {
 // Initialize Desmos graph on load
 window.addEventListener('load', () => {
   const el = document.getElementById('desmos');
@@ -5,4 +6,5 @@ window.addEventListener('load', () => {
     const calculator = Desmos.GraphingCalculator(el, { expressions: false });
     calculator.setExpression({ id: 'line', latex: 'y=-2/3 x + 373.15' });
   }
+});
 });

--- a/assets/js/slide-engine.js
+++ b/assets/js/slide-engine.js
@@ -1,0 +1,17 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const md = sessionStorage.getItem('mdSource');
+  if(!md){ alert('Kein Markdown im Speicher – bitte zuerst Datei hochladen.'); return; }
+
+  const host = document.querySelector('.reveal .slides');
+  md.split(/^---$/m).forEach(chunk=>{
+    const sec=document.createElement('section');
+    sec.innerHTML = marked.parse(chunk.trim());
+    host.appendChild(sec);
+  });
+
+  /* Widgets initialisieren */
+  document.dispatchEvent(new Event('slides-ready'));
+
+  /* Reveal erst starten, wenn Slides drin sind */
+  Reveal.initialize({ hash:true, slideNumber:true, width:1280, height:720, margin:0.05 });
+});

--- a/assets/js/uploader.js
+++ b/assets/js/uploader.js
@@ -1,0 +1,17 @@
+const drop = document.getElementById('dropZone');
+const fileInput = document.getElementById('mdUpload');
+
+/* Hover‑Effekte */
+['dragenter','dragover'].forEach(ev=>drop.addEventListener(ev,e=>{e.preventDefault();drop.classList.add('hover');}));
+['dragleave','drop'].forEach(ev=>drop.addEventListener(ev,e=>{e.preventDefault();drop.classList.remove('hover');}));
+
+/* Datei empfangen */
+drop.addEventListener('drop',   e=>handle(e.dataTransfer.files[0]));
+fileInput.addEventListener('change',e=>handle(e.target.files[0]));
+
+function handle(file){
+  if(!file || !file.name.endsWith('.md')) return alert('Bitte eine .md‑Datei wählen!');
+  const r=new FileReader();
+  r.onload=()=>{ sessionStorage.setItem('mdSource', r.result); location.href='viewer.html'; };
+  r.readAsText(file,'utf-8');
+}

--- a/assets/js/widget-factory.js
+++ b/assets/js/widget-factory.js
@@ -1,0 +1,29 @@
+document.addEventListener('slides-ready', ()=>{
+
+  document.querySelectorAll('widget').forEach(tag=>{
+    const t = tag.getAttribute('type');
+    if(t==='slider') makeSlider(tag);
+    if(t==='reveal') makeReveal(tag);
+  });
+
+  /* -------- Funktionen -------- */
+  function makeSlider(el){
+    const out = el.dataset.for;
+    const range = Object.assign(document.createElement('input'),{
+      type:'range', min:el.dataset.min||0, max:el.dataset.max||10, value:el.dataset.init||0
+    });
+    range.oninput = ()=>{ const x=+range.value;
+      document.getElementById(out).innerHTML = Function('x',`return ${el.dataset.fn}`)(x);
+      MathJax.typesetPromise();
+    };
+    el.replaceWith(range);
+  }
+
+  function makeReveal(el){
+    const btn=document.createElement('button');
+    btn.textContent=el.dataset.label||'zeigen';
+    btn.onclick=()=>document.getElementById(el.dataset.for).classList.toggle('visible');
+    el.replaceWith(btn);
+  }
+
+});

--- a/index.html
+++ b/index.html
@@ -3,142 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Mathematik-Folien</title>
+  <title>.md \u2192 Interaktive Pr\u00e4sentation</title>
 
-  <!-- Reveal Grund-CSS  -->
-  <link rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.css">
-  <link rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/theme/black.css" id="theme">
-
-  <!-- Eigenes Dark-Theme (identisch zur Upload-Seite) -->
+  <!-- ----- Dark\u2011Theme + Widget\u2011Grundstyles ----- -->
   <link rel="stylesheet" href="assets/css/style.css">
-
-  <!-- Polyfills & MathJax -->
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script async id="MathJax-script"
-          src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
 </head>
-
 <body>
-<div class="reveal"><div class="slides">
+  <h1 class="title">Markdown\u2011Datei hochladen</h1>
 
-<!-- ====================================================== -->
-<section>
-  <h2>Klammern: jeden Term mit jedem anderen multiplizieren</h2>
-  <ul>
-    <li class="fragment">Bei mehreren Faktoren: jeden genau einmal verwenden, die Reihenfolge spielt keine Rolle</li>
-    <li class="fragment math">\(3x\,(2x+5y^{2}) = 6x^{2} + 15xy^{2}\)</li>
-    <li class="fragment math">\((-7xz^{3}+3xy^{2})\cdot(-2xz) = 14x^{2}z^{4}-6x^{2}y^{2}z\)</li>
-    <li class="fragment math">\((3x-7y)(2x+5y) = 6x^{2}+xy-35y^{2}\)</li>
-    <li class="fragment math">\(2(x+3)(x+7) = 2x^{2}+20x+42\)</li>
-    <li class="fragment math">\(3x^{2}(x-3)(9x-1) = 27x^{4}-84x^{3}+9x^{2}\)</li>
-  </ul>
-</section>
+  <!-- Drag\u2011&\u2011Drop / File\u2011Picker -->
+  <label id="dropZone">
+    <input type="file" id="mdUpload" accept=".md">
+    <!-- Heroicons: “Cloud Upload” -->
+    <svg width="72" height="72" viewBox="0 0 24 24"><path d="M12 16l4-5h-3V4h-2v7H8l4 5z"/><path d="M20 18H4v-2h16v2z"/></svg>
+    <p><strong>Datei hierher ziehen</strong><br>oder klicken \u2026</p>
+  </label>
 
-<section>
-  <h2>Binomische Formeln – Abkürzung für häufige Produkte</h2>
-  <ul>
-    <li class="fragment math">\((a+b)^{2}=a^{2}+2ab+b^{2}\)</li>
-    <li class="fragment math">\((a-b)^{2}=a^{2}-2ab+b^{2}\)</li>
-    <li class="fragment math">\((a+b)(a-b)=a^{2}-b^{2}\)</li>
-  </ul>
-</section>
-
-<section>
-  <h2>Schnelles Ausmultiplizieren mittels Binomen</h2>
-  <ul>
-    <li class="fragment math">\((u-10)(u+10)=u^{2}-100\)</li>
-    <li class="fragment math">\((x+3y)^{2}=x^{2}+6xy+9y^{2}\)</li>
-    <li class="fragment math">\((5x-4z)^{2}=25x^{2}-40xz+16z^{2}\)</li>
-    <li class="fragment math">\((x^{2}y+1)(x^{2}y-1)=x^{4}y^{2}-1\)</li>
-    <li class="fragment math">\((2x-w^{10})^{2}=4x^{2}-4xw^{10}+w^{20}\)</li>
-    <li class="fragment math">\((w+\tfrac{4}{3})^{2}=w^{2}+\tfrac{8}{3}w+\tfrac{16}{9}\)</li>
-  </ul>
-</section>
-
-<section>
-  <h2>Faktorisieren – Zweiklammer-Ansatz</h2>
-  <p class="fragment">Beispiel: \(x^{2}+1x-6\) → \((x-2)(x+3)\)</p>
-  <ol>
-    <li class="fragment">Faktor \(x\) aus \(x^{2}\) → erste Glieder</li>
-    <li class="fragment">Zerlege \(-6\) in Paare, teste bis Mittelterm passt</li>
-    <li class="fragment">Faktorisiert: \((x-2)(x+3)\)</li>
-  </ol>
-</section>
-
-<section>
-  <h2>Einsetzverfahren (Gleichungssystem)</h2>
-  <p>\(\begin{cases}2y = 7 + x\\-3x+8 = y+1\end{cases}\)</p>
-  <ol>
-    <li class="fragment">Löse (II) nach \(x\) → \(x=\tfrac{y}{-3}+\tfrac{7}{3}\)</li>
-    <li class="fragment">Setze in (I) ein → \(y=4\)</li>
-    <li class="fragment">Ergebnis: \(x=1\), Lösung \(L=\{(1,4)\}\)</li>
-  </ol>
-</section>
-
-<section>
-  <h2>Wurzelgleichungen quadrieren</h2>
-  <p class="fragment math">\((5\sqrt{x-2}-6)^{2}=25(x-2)-60\sqrt{x-2}+36\)</p>
-</section>
-
-<section>
-  <h2>Wurzelgleichungen – vollständige Lösung</h2>
-  <ol>
-    <li class="fragment">Ausgang: \(2\sqrt{-2x+2}+3=3x\)</li>
-    <li class="fragment">Quadrieren → \(9x^{2}-10x+1=0\)</li>
-    <li class="fragment">Lösungen: \(x_{1}=1,\;x_{2}=\tfrac19\) (Probe → nur \(x=1\))</li>
-  </ol>
-</section>
-
-<section>
-  <h2>Lineare Funktionen – Delisle ↔ Kelvin</h2>
-  <ul>
-    <li class="fragment">Stützpunkte: \((150,273{,}15)\) & \((0,373{,}15)\)</li>
-    <li class="fragment">Steigung: \(m=-\tfrac23\)</li>
-    <li class="fragment">Gerade: \(y=-\tfrac23x+373{,}15\)</li>
-  </ul>
-</section>
-
-<section>
-  <h2>Interaktives Diagramm</h2>
-  <div id="desmos" class="desmos-graph"></div>
-</section>
-
-<section>
-  <h2>Zusammenfassung</h2>
-  <table>
-    <thead><tr><th>Thema</th><th>Konzept</th></tr></thead>
-    <tbody>
-      <tr><td>Klammern</td><td>Distributivgesetz</td></tr>
-      <tr><td>Binomische Formeln</td><td>Spezial-Produkte</td></tr>
-      <tr><td>Faktorisieren</td><td>Zweiklammer-Ansatz</td></tr>
-      <tr><td>Einsetzverfahren</td><td>Lineare Gleichungen</td></tr>
-      <tr><td>Wurzelgleichungen</td><td>Radikale eliminieren</td></tr>
-      <tr><td>Lineare Funktionen</td><td>Gerade durch 2 Punkte</td></tr>
-    </tbody>
-  </table>
-</section>
-<!-- ====================================================== -->
-
-</div></div><!-- reveal / slides -->
-
-<!-- Reveal- & Desmos-JS -->
-<script src="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.js"></script>
-<script src="https://www.desmos.com/api/v1.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>
-<script src="assets/js/script.js"></script>
-
-<script>
-  /*  >>>  Reveal Setup  — kein Auto-Scaling mehr  <<<  */
-  Reveal.initialize({
-    hash: true,
-    slideNumber: true,
-    width: 1280,
-    height: 720,
-    margin: 0.05,
-    minScale: 1,
-    maxScale: 1
-  });
-</script>
+  <script src="assets/js/uploader.js"></script>
 </body>
 </html>

--- a/viewer.html
+++ b/viewer.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Mathematik‑Folien</title>
+
+  <!-- Reveal CSS -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/theme/black.css" id="theme">
+
+  <!-- Eigenes Dark‑Theme, identisch zu index.html -->
+  <link rel="stylesheet" href="assets/css/style.css">
+
+  <!-- Polyfills & MathJax -->
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script async id="MathJax-script"
+          src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+</head>
+
+<body>
+  <div class="reveal"><div class="slides"><!-- Slides werden per JS eingefügt --></div></div>
+
+  <!-- Reveal & Desmos -->
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4/dist/reveal.js"></script>
+  <script src="https://www.desmos.com/api/v1.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>
+
+  <!-- Eigene Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+  <script src="assets/js/slide-engine.js"></script>
+  <script src="assets/js/widget-factory.js"></script>
+  <script src="assets/js/script.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add a minimalist upload page
- implement a Reveal-based viewer page
- provide JS for uploading and slide generation
- wrap existing graph script with a `slides-ready` listener
- use shared dark theme and widget styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68650f998f04832688ab61c4ba3827eb