### PR TITLE
Fix scaling and fragment rendering

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,6 +7,8 @@
 
 /* Grundlayout (gilt f\u00fcr beide Seiten) */
 *{box-sizing:border-box;margin:0;padding:0}
+.reveal ul, .reveal ol{margin-left:1.2em;}
+.reveal h1, .reveal h2, .reveal p{margin:0 0 0.6em;}
 html,body{height:100%;font-family:"Inter",system-ui,sans-serif;background:var(--bg-900);color:var(--txt-100);}
 .title{text-align:center;font-size:clamp(1.3rem,2vw+1rem,1.8rem);margin:2rem 0 1rem}
 
@@ -31,4 +33,6 @@ button{padding:.4em .8em;border:none;border-radius:4px;cursor:pointer;
        background:var(--accent);color:#fff;font-size:.9rem}
 button:hover{background:var(--accent-light);}
 .hidden{display:none}.visible{display:block}
+
+.reveal section{font-size:0.9em;}
 

--- a/assets/js/slide-engine.js
+++ b/assets/js/slide-engine.js
@@ -6,13 +6,20 @@ window.addEventListener('DOMContentLoaded', () => {
   }
 
   /* Meta-Block am Anfang entfernen */
-  const meta=/^<!--\s*meta\s*-->[\s\S]*?^---\s*$/m;
+  const meta=/^<!--\s*meta\s*-->[\s\S]*?\n---\s*$/m;
   if(meta.test(md)) md=md.replace(meta,'');
 
   const host = document.querySelector('.reveal .slides');
   md.split(/^---$/m).forEach(chunk=>{
     const sec=document.createElement('section');
     sec.innerHTML = marked.parse(chunk.trim());
+    sec.querySelectorAll('fragment').forEach(frag=>{
+      const span=document.createElement('span');
+      span.innerHTML=frag.innerHTML;
+      span.classList.add('fragment','fade-in');
+      frag.replaceWith(span);
+    });
+    sec.querySelectorAll('li').forEach(li=>li.classList.add('fragment','fade-in'));
     host.appendChild(sec);
   });
 
@@ -20,5 +27,5 @@ window.addEventListener('DOMContentLoaded', () => {
   document.dispatchEvent(new Event('slides-ready'));
 
   /* Reveal erst starten, wenn Slides drin sind */
-  Reveal.initialize({ hash:true, slideNumber:true, width:1280, height:720, margin:0.05 });
+  Reveal.initialize({ hash:true, slideNumber:true, width:1280, height:720, margin:0.05, minScale:0.2, maxScale:1.5 });
 });

--- a/assets/js/widget-factory.js
+++ b/assets/js/widget-factory.js
@@ -12,10 +12,16 @@ document.addEventListener('slides-ready', ()=>{
     const range = Object.assign(document.createElement('input'),{
       type:'range', min:el.dataset.min||0, max:el.dataset.max||10, value:el.dataset.init||0
     });
-    range.oninput = ()=>{ const x=+range.value;
-      document.getElementById(out).innerHTML = Function('x',`return ${el.dataset.fn}`)(x);
-      MathJax.typesetPromise();
-    };
+      range.oninput = ()=>{ const x=+range.value;
+        const target = document.getElementById(out) || (function(){
+          const d=document.createElement('div');
+          d.id=out;
+          el.parentNode.insertBefore(d, el.nextSibling);
+          return d;
+        })();
+        target.innerHTML = Function('x', 'return '+ el.dataset.fn)(x);
+        MathJax.typesetPromise();
+      };
     el.replaceWith(range);
   }
 


### PR DESCRIPTION
## Summary
- adjust Reveal.js initialization for proper scaling
- support fragment tags and list items for stepwise reveals
- ensure slider widget creates output and handles function strings
- tweak global styles for Reveal slides

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686516a79e5483269d09a84ab77fbc2d